### PR TITLE
Adds initial Docker components

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,44 @@ A humble discord bot
 
 ## Tools
 
-- For programming language versions, check out `.tool-versions`
+For programming language, and other tools, check out `.tool-versions` (I tend to use asdf where I can!)
+
 - asdf version manager: https://asdf-vm.com/guide/getting-started.html#getting-started
+- Docker: https://docs.docker.com/get-docker/
 
 ## Project Structure
 
 - Golang Standards: https://github.com/golang-standards/project-layout
 - How do I structure my go project?: https://www.wolfe.id.au/2020/03/10/how-do-i-structure-my-go-project/
+
+## Use of BOT_TOKEN
+
+Within the source code, you may have noticed that BOT_TOKEN is retrieving an environment variable. Personally, I use `direnv` (read more [here](https://direnv.net/)) installed via `asdf` and place a `.envrc` file in the root of the repository and work from that.
+
+When deployed in "production", because the bot is running as a containerised app, the environment variable can just be passed through a secrets manager tool, like in [AWS ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html#secrets-envvar).
+
+All in all, this makes local development portable, and doesn't require production-specific logic to be put in place.
+
+Ultimately it is up to you how you want to define the environment variable, though you need to make sure not to leak any tokens in source code :^)
+
+## Working with the container
+
+Assuming you have Docker (or any appropriate containerisation tool) installed, and ready to go, the commands are pretty trivial:
+
+### Build the Image locally
+
+```sh
+docker build \
+-t "<name-for-container>:<tag>"
+#e.g. docker build -t "ralphbot-test:unstable"
+```
+
+### Run the container
+
+```sh
+docker run -it \
+-e BOT_TOKEN \
+<name-for-container>:<tag>
+```
+
+_Note_: BOT_TOKEN needs to be defined.

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Ultimately it is up to you how you want to define the environment variable, thou
 
 ## Working with the container
 
-Assuming you have Docker (or any appropriate containerisation tool) installed, and ready to go, the commands are pretty trivial:
+Assuming you have Docker (or any appropriate containerisation tool) installed, and your `$(pwd)` is `src/`, the basic commands are:
 
 ### Build the Image locally
 
 ```sh
 docker build \
--t "<name-for-container>:<tag>"
+-t "<name-for-container>:<tag>" .
 #e.g. docker build -t "ralphbot-test:unstable"
 ```
 

--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -1,0 +1,5 @@
+# Common
+README.md
+CHANGELOG.md
+docker-compose.yml
+Dockerfile

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -6,7 +6,8 @@ COPY . ./
 
 RUN go mod download && go mod verify
 RUN CGO_ENABLED=0 go build -v -o /tmp/build/ralphbot ./...
-#CGO_ENABLED=0 to force a static build. Next stage of build uses an image that doesn't have *all* libraries
+#CGO_ENABLED=0 to force a static build. Next stage of build uses an image that has libraries in different locations
+#https://stackoverflow.com/a/36308464
 
 FROM public.ecr.aws/docker/library/golang:1.17.8-alpine
 WORKDIR /app

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,14 @@
+FROM public.ecr.aws/docker/library/golang:1.17.8 as build_image
+
+WORKDIR /app
+
+COPY . ./
+
+RUN go mod download && go mod verify
+RUN CGO_ENABLED=0 go build -v -o /tmp/build/ralphbot ./...
+#CGO_ENABLED=0 to force a static build. Next stage of build uses an image that doesn't have *all* libraries
+
+FROM public.ecr.aws/docker/library/golang:1.17.8-alpine
+WORKDIR /app
+COPY --from=build_image /tmp/build/ralphbot ./
+CMD [ "./ralphbot" ]


### PR DESCRIPTION
# Purpose :dart:

Ralphbot was always intended to run as a containerised application. This is a design decision to both provide ease of local development, and ease of deployment into production (when that time arrives).

Additionally, the readme has been updated to provide guidance on how to locally develop Ralphbot.

# Context :brain:
- https://github.com/therealvio/ralphbot/issues/3

# Notes 📓 
- Due to how alpine-linux stores its libraries, go binaries have a hard time dynamically linking. There are workarounds, but for the time being a static build will do the job just fine for now, refer to: https://stackoverflow.com/a/36308464
