### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template---for-developers.md
+++ b/.github/ISSUE_TEMPLATE/issue-template---for-developers.md
@@ -1,0 +1,13 @@
+---
+name: Issue Template - For developers
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+- Give context to what the issue is
+- Emphasise outcomes, over how you do it. i.e. Make sure to state the **outcome** of the work. e.g. "The **outcome** of this `issue` is..."
+ --!>


### PR DESCRIPTION
# Purpose :dart:

These changes aim to help facilitate standards when creating new issues for Ralphbot with the use of a template.

When defining work, I have personally learned that focusing on outcomes rather than "how" I do it in the original message. The "how" comes with either a discovery issue/card/ticket, or shared within the comments - the point is that better tools exist for planning the how, and the artefacts can be shared in the original issue/card/ticket. 

# Context :brain:

No context here! 👀 