### PR TITLE
Adds vpc construct, and migrates ralphobot to vpc

### DIFF
--- a/ops/src/index.ts
+++ b/ops/src/index.ts
@@ -3,7 +3,7 @@ import "source-map-support/register"
 import * as cdk from "aws-cdk-lib"
 import { AppExtension } from "./app"
 import { RalphbotEcrStack } from "./stacks/ralphbot-ecr-stack"
-import { RalphbotStack } from "./stacks/ralphbot-stack"
+import { RalphbotStack } from "./stacks/ralphbot-ops-stack"
 
 const {
   COMMIT: commit,


### PR DESCRIPTION
# Purpose :dart:

These changes are part of an effort to lower the running cost of Ralphbot. A bulk of it comes from NAT gateway hours. Since 2 of these NAT Gateways are deployed over 2 AZs, it makes sense to just shift Ralphbot into a single AZ.

# Context :brain:

Ralphbot is costing $1.50-$2.00 USD daily to run, this is part of an effort to reduce daily costs.

Ralphbot is purely a hobby project at this point in time, so the expectation to have it any more highly available than a single AZ is just silly.
