### PR TITLE
Removes NAT, makes ralphbot public

### DIFF
--- a/ops/src/stacks/ralphbot-ops-stack.ts
+++ b/ops/src/stacks/ralphbot-ops-stack.ts
@@ -19,7 +19,8 @@ export class RalphbotStack extends Stack {
     super(scope, id, props)
 
     const vpc = new ec2.Vpc(this, "vpc", {
-      maxAzs: 1
+      maxAzs: 1,
+      natGateways: 0
     })
 
     const repositoryRef = ecr.Repository.fromRepositoryArn(
@@ -34,7 +35,7 @@ export class RalphbotStack extends Stack {
     )
 
     const cluster = new ecs.Cluster(this, "Cluster", {
-      vpc: vpc
+      vpc: vpc,
     })
     const taskDefinition = new ecs.FargateTaskDefinition(
       this,
@@ -76,10 +77,13 @@ export class RalphbotStack extends Stack {
       }),
     })
     new ecs.FargateService(this, "Service", {
-      cluster,
-      taskDefinition,
+      assignPublicIp: true,
+      cluster: cluster,
+      taskDefinition: taskDefinition,
       circuitBreaker: { rollback: true },
-      vpcSubnets: vpc.selectSubnets({subnetType: ec2.SubnetType.PRIVATE_WITH_NAT})
+      vpcSubnets: vpc.selectSubnets({
+        subnetType: ec2.SubnetType.PUBLIC,
+      }),
     })
   }
 }


### PR DESCRIPTION
# Purpose :dart:

These changes removes NAT settings for Ralphbot's VPC. Rendering Ralphbot as Fargate task running on a public subnet. This is due to NAT Gateways costing an amount of money that isn't worth paying for as a hobby project.

# Context :brain:

Ralphbot's cost, although at a slower burn rate than changes before #13, it's still too expensive.

# Notes 📓 
- This change is a quick-fire solution to reduce running costs on Ralphbot. After CI/CD has been implemented in a future PR, a proper pass as setting up a [NAT Instance](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_NAT_Instance.html), however due to AWS Linux 1 NAT AMI [being EOL](https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life/), this warrants putting a little more thought into it.