### PR TITLE
Fixes `deploy` workflow dependency

### DIFF
--- a/.github/workflows/ralphbot-deploy.yaml
+++ b/.github/workflows/ralphbot-deploy.yaml
@@ -2,10 +2,8 @@ name: Ralphbot Master Actions
 on: 
   workflow_run:
     workflows:
-      - Ralphbot Source Code Test Actions
-      - Ralphbot CDK Test Actions
+      - Ralphbot Test Actions
     branches:
-      - extend-cicd
       - master
     types:
       - completed


### PR DESCRIPTION
# Purpose :dart:

These changes aim to fix the `deploy` workflow where it doesn't run following the completion of the` test` workflow.

# Context :brain:

Merging of #22 did not trigger the `deploy` workflow after testing was complete.
