### PR TITLE
chore: set renovate pr rate to default

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,6 @@
   "extends": ["config:base", ":dependencyDashboard"],
   "ignorePaths": ["src/Dockerfile", "ops/Dockerfile"],
   "schedule": ["after 7am on Tuesday"],
-  "ignorePresets": [":prHourlyLimit2"],
   "packageRules": [
     {
       "groupName": "ci/cd dependencies",


### PR DESCRIPTION
# Purpose :dart:

By default, renovate limits its PR generation to 2 PRs an hour. These changes reduce the amount of noise renovate will make when discovering dependencies that require updating.

# Context :brain:

These changes are part of an effort to set up dependency management for `Ralphbot` #35 

