### PR TITLE
chore: set renovate automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,29 +13,39 @@
     {
       "groupName": "ralphbot dependencies",
       "matchManagers": ["gomod"],
-      "matchPaths": ["src/"]
+      "matchPaths": ["src/"],
+      "automerge": true,
+      "automergeType": "branch"
     },
     {
       "groupName": "linting dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["prettier"],
       "matchPackagePrefixes": ["@typescript-eslint/", "eslint"],
-      "matchPackagePatterns": ["eslint"]
+      "matchPackagePatterns": ["eslint"],
+      "automerge": true,
+      "automergeType": "branch"
     },
     {
       "groupName": "testing dependencies",
       "matchDepTypes": ["devDependencies"],
-      "matchPackageNames": ["jest", "ts-jest", "@types/jest"]
+      "matchPackageNames": ["jest", "ts-jest", "@types/jest"],
+      "automerge": true,
+      "automergeType": "branch"
     },
     {
       "groupName": "nodejs dependencies",
       "matchDepTypes": ["devDependencies"],
-      "matchPackageNames": ["@types/node", "ts-node"]
+      "matchPackageNames": ["@types/node", "ts-node"],
+      "automerge": true,
+      "automergeType": "branch"
     },
     {
       "groupName": "nodejs runtime",
       "allowedVersions": "^16.0.0",
-      "matchPackageNames": ["node"]
+      "matchPackageNames": ["node"],
+      "automerge": true,
+      "automergeType": "branch"
     },
     {
       "groupName": "aws cdk dependencies",


### PR DESCRIPTION
# Purpose :dart:

These changes add branch auto merging for `renovate`, in which should minimize the amount of noise the renovate will make when dependency updates are available. i.e. If the PR tests pass, then the changes can be merged.

# Context :brain:

Part of an effort to add dependency management to `ralphbot` #35 
