### PR TITLE
chore: tweak renovate strategy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":dependencyDashboard"],
+  "extends": ["config:base", ":dependencyDashboard", ":rebaseStalePrs"],
   "ignorePaths": ["src/Dockerfile", "ops/Dockerfile"],
   "schedule": ["after 7am on Tuesday"],
+  "stabilityDays": 14,
   "packageRules": [
     {
       "groupName": "ci/cd dependencies",
@@ -18,7 +19,7 @@
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "linting dependencies",
+      "groupName": "ts linting dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["prettier"],
       "matchPackagePrefixes": ["@typescript-eslint/", "eslint"],
@@ -28,17 +29,9 @@
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "testing dependencies",
+      "groupName": "ts testing dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["jest", "ts-jest", "@types/jest"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "squash"
-    },
-    {
-      "groupName": "nodejs dependencies",
-      "matchDepTypes": ["devDependencies"],
-      "matchPackageNames": ["@types/node", "ts-node"],
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
@@ -52,8 +45,24 @@
       "automergeStrategy": "squash"
     },
     {
+      "groupName": "nodejs dependencies",
+      "matchDepTypes": ["devDependencies"],
+      "matchPackageNames": ["@types/node", "ts-node"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
       "groupName": "aws cdk dependencies",
       "matchPackageNames": ["constructs", "aws-cdk", "aws-cdk-lib"]
+    },
+    {
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "automerge": true,
+      "automergeType": "branch"
     }
   ]
 }


### PR DESCRIPTION
# Purpose :dart:

A new block has been added for minor, and patch updates to be put
together as a single PR. This should hopefully reduce the amount of
noise that `renovate` makes.

There scenarios where minor and patch updates for multiple packages
could be released, so having a single PR rather than `x` amount of
releases was determined to be beneficial.

A wait time has been added to update dependencies where
they must have been made available after 14 days (in case the dependency
has been revoked). This will promote a stable dependency upgrade
process.

And finally, a strategy to refresh stale PRs has been added. Let's be
honest, PRs may be up for a while, so we may as well keep them fresh.

# Context :brain:

Part of an effort to add dependency management for `ralphbot` #35
