### PR TITLE
ci: Updates default brain to main

### DIFF
--- a/.github/workflows/ralphbot-deploy.yaml
+++ b/.github/workflows/ralphbot-deploy.yaml
@@ -4,7 +4,7 @@ on:
     workflows:
       - Ralphbot Test Actions
     branches:
-      - master
+      - main
     types:
       - completed
 


### PR DESCRIPTION
# Purpose :dart:

These changes fix the Github workflows that were originally pointing to "master", without these changes the workflows cease to trigger following the default branch renaming to "main".

# Context :brain:

"master" branch has been renamed to "main", redundant branch refs have
been made to just "on push anywhere".

Following the default branch rename, workflows that refer to the
"master" branch no longer work. These changes fix this.

- Renaming Master: https://github.com/github/renaming
