### PR TITLE
Reconfigure Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,6 @@
       "groupName": "ralphbot dependencies",
       "matchManagers": ["gomod"],
       "matchPaths": ["src/"],
-      "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
     },
@@ -23,7 +22,6 @@
       "matchPackageNames": ["prettier"],
       "matchPackagePrefixes": ["@typescript-eslint/", "eslint"],
       "matchPackagePatterns": ["eslint"],
-      "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
     },
@@ -31,7 +29,6 @@
       "groupName": "testing dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["jest", "ts-jest", "@types/jest"],
-      "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
     },
@@ -39,7 +36,6 @@
       "groupName": "nodejs dependencies",
       "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["@types/node", "ts-node"],
-      "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
     },
@@ -47,7 +43,6 @@
       "groupName": "nodejs runtime",
       "allowedVersions": "^16.0.0",
       "matchPackageNames": ["node"],
-      "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "squash"
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,6 @@
       "groupName": "ralphbot dependencies",
       "matchManagers": ["gomod"],
       "matchPaths": ["src/"],
-      "automergeType": "pr",
       "automergeStrategy": "squash"
     },
     {
@@ -21,26 +20,22 @@
       "matchPackageNames": ["prettier"],
       "matchPackagePrefixes": ["@typescript-eslint/", "eslint"],
       "matchPackagePatterns": ["eslint"],
-      "automergeType": "pr",
       "automergeStrategy": "squash"
     },
     {
       "groupName": "jest",
       "matchPackageNames": ["jest", "ts-jest", "@types/jest"],
-      "automergeType": "pr",
       "automergeStrategy": "squash"
     },
     {
       "groupName": "nodejs",
       "matchPackageNames": ["@types/node", "ts-node"],
-      "automergeType": "pr",
       "automergeStrategy": "squash"
     },
     {
       "groupName": "nodejs",
       "allowedVersions": "^16.0.0",
       "matchPackageNames": ["node"],
-      "automergeType": "pr",
       "automergeStrategy": "squash"
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,8 @@
     {
       "groupName": "ci/cd dependencies",
       "matchManagers": ["github-actions"],
-      "matchPaths": [".github/workflows/"]
+      "matchPaths": [".github/workflows/"],
+      "automergeStrategy": "squash"
     },
     {
       "groupName": "ralphbot dependencies",
@@ -40,7 +41,8 @@
     },
     {
       "groupName": "aws cdk",
-      "matchPackageNames": ["constructs", "aws-cdk", "aws-cdk-lib"]
+      "matchPackageNames": ["constructs", "aws-cdk", "aws-cdk-lib"],
+      "automergeStrategy": "squash"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,7 @@
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "linting dependencies",
+      "groupName": "eslint",
       "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["prettier"],
       "matchPackagePrefixes": ["@typescript-eslint/", "eslint"],
@@ -26,28 +26,28 @@
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "testing dependencies",
+      "groupName": "jest",
       "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["jest", "ts-jest", "@types/jest"],
       "automergeType": "pr",
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "nodejs dependencies",
+      "groupName": "nodejs",
       "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["@types/node", "ts-node"],
       "automergeType": "pr",
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "nodejs runtime",
+      "groupName": "nodejs",
       "allowedVersions": "^16.0.0",
       "matchPackageNames": ["node"],
       "automergeType": "pr",
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "aws cdk dependencies",
+      "groupName": "aws cdk",
       "matchPackageNames": ["constructs", "aws-cdk", "aws-cdk-lib"]
     }
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,6 @@
     },
     {
       "groupName": "eslint",
-      "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["prettier"],
       "matchPackagePrefixes": ["@typescript-eslint/", "eslint"],
       "matchPackagePatterns": ["eslint"],
@@ -27,14 +26,12 @@
     },
     {
       "groupName": "jest",
-      "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["jest", "ts-jest", "@types/jest"],
       "automergeType": "pr",
       "automergeStrategy": "squash"
     },
     {
       "groupName": "nodejs",
-      "matchDepTypes": ["devDependencies"],
       "matchPackageNames": ["@types/node", "ts-node"],
       "automergeType": "pr",
       "automergeStrategy": "squash"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,42 +5,35 @@
   "schedule": ["after 7am and before 7pm every weekday"],
   "packageRules": [
     {
-      "groupName": "ci/cd dependencies",
       "matchManagers": ["github-actions"],
       "matchPaths": [".github/workflows/"],
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "ralphbot dependencies",
       "matchManagers": ["gomod"],
       "matchPaths": ["src/"],
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "eslint",
       "matchPackageNames": ["prettier"],
       "matchPackagePrefixes": ["@typescript-eslint/", "eslint"],
       "matchPackagePatterns": ["eslint"],
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "jest",
       "matchPackageNames": ["jest", "ts-jest", "@types/jest"],
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "nodejs",
       "matchPackageNames": ["@types/node", "ts-node"],
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "nodejs",
       "allowedVersions": "^16.0.0",
       "matchPackageNames": ["node"],
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "aws cdk",
       "matchPackageNames": ["constructs", "aws-cdk", "aws-cdk-lib"],
       "automergeStrategy": "squash"
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":dependencyDashboard"],
   "ignorePaths": ["src/Dockerfile", "ops/Dockerfile"],
-  "schedule": ["after 7am on Tuesday"],
+  "schedule": ["after 7am and before 7pm every weekday"],
   "packageRules": [
     {
       "groupName": "ci/cd dependencies",


### PR DESCRIPTION
# Purpose :dart:

These changes attempt to further simplify and tidy up configurations for `renovate` in this repository following the revert PR: #59.


# Context :brain:

Prior to the changes in #59, `renovate` was failing to set up PRs. This is likely in part because the configurations set for renovate at the time were incorrect.
