### PR TITLE
Renovate tweaks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,7 @@
       "automergeStrategy": "squash"
     },
     {
+      "groupName": "jest",
       "matchPackageNames": ["jest", "ts-jest", "@types/jest"],
       "automergeStrategy": "squash"
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,8 +11,14 @@
       "automergeStrategy": "squash"
     },
     {
+      "groupName": "golang",
       "matchManagers": ["gomod"],
-      "matchPaths": ["src/"],
+      "automergeStrategy": "squash"
+    },
+    {
+      "groupName": "golang",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["go"],
       "automergeStrategy": "squash"
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,9 +15,7 @@
       "automergeStrategy": "squash"
     },
     {
-      "matchPackageNames": ["prettier"],
       "matchPackagePrefixes": ["@typescript-eslint/", "eslint"],
-      "matchPackagePatterns": ["eslint"],
       "automergeStrategy": "squash"
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,10 +25,12 @@
       "automergeStrategy": "squash"
     },
     {
+      "groupName": "nodejs",
       "matchPackageNames": ["@types/node", "ts-node"],
       "automergeStrategy": "squash"
     },
     {
+      "groupName": "nodejs",
       "allowedVersions": "^16.0.0",
       "matchPackageNames": ["node"],
       "automergeStrategy": "squash"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,7 @@
       "automergeStrategy": "squash"
     },
     {
+      "groupName": "eslint",
       "matchPackagePrefixes": ["@typescript-eslint/", "eslint"],
       "automergeStrategy": "squash"
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:base", ":dependencyDashboard"],
   "ignorePaths": ["src/Dockerfile", "ops/Dockerfile"],
   "schedule": ["after 7am and before 7pm every weekday"],
+  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
# Purpose :dart:

These changes re-add group names to some dependency groups in an effort to maintain naming consistency following testing done in  #66 
