### PR TITLE
chore(renovate): Adds aws-cdk groupName

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,6 +43,7 @@
       "automergeStrategy": "squash"
     },
     {
+      "groupName": "aws-cdk",
       "matchPackageNames": ["constructs", "aws-cdk", "aws-cdk-lib"],
       "automergeStrategy": "squash"
     }


### PR DESCRIPTION
# Purpose :dart:

These changes add a groupName to `aws-cdk` package rules. This was missing in #71 