### PR TITLE
chore(renovate): Removes groupName for go deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,6 @@
       "automergeStrategy": "squash"
     },
     {
-      "groupName": "golang",
       "matchManagers": ["gomod"],
       "automergeStrategy": "squash"
     },


### PR DESCRIPTION
# Purpose :dart:

The groupName for golang dependendencies has been removed.
This is has been changed because there isn't a sensible grouping
requirement for `golang` dependendencies at this point in time.

Right now, only the `golang` language should be explictly grouped by
itself.
