### PR TITLE
Add `Makefile`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,8 @@ Thumbs.db
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Build Outputs
+src/bin/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -5,12 +5,12 @@ WORKDIR /app
 COPY . ./
 
 RUN go mod download && go mod verify
-RUN CGO_ENABLED=0 go build -v -o /tmp/build/ralphbot/ ./...
+RUN GOOS=linux CGO_ENABLED=0 go build -v -o bin/ralphbot ./cmd/ralphbot
 #CGO_ENABLED=0 to force a static build. Next stage of build uses an image that has libraries in different locations
 #https://stackoverflow.com/a/36308464
 
 FROM public.ecr.aws/docker/library/golang:1.18.3-alpine
 WORKDIR /app
-COPY --from=build_image /tmp/build/ralphbot/ ./
+COPY --from=build_image /app/bin/ralphbot ./
 COPY --from=build_image /app/internal/dadjoke/jokes.json ./
 CMD [ "./ralphbot" ]

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,13 @@
+bin:
+	mkdir ./bin
+
+clean:
+	rm -rf ./bin
+
+.PHONY: mod
+mod:
+	go mod download
+
+.PHONY: build
+build: bin mod
+	GOOS=linux CGO_ENABLED=0 go build -v -o bin/ralphbot ./cmd/ralphbot


### PR DESCRIPTION
# Purpose :dart:

These changes add a Makefile to the `golang` portion of the `ralphbot` codebase. This is a first step towards streamlining the build, (eventual) test, and local development processes concerning `ralphbot. By using `make` targets, complicated commands can be both documented and condensed into simpler commands.

# Context :brain:

Part of a later effort to enhance the local development experience with `ralphbot`, which will directly impact `ralphbot`'s refactoring and test suite additions.
