### PR TITLE
ci: Adds path specification to infra linting

### DIFF
--- a/.github/workflows/ralphbot-infra-lint.yaml
+++ b/.github/workflows/ralphbot-infra-lint.yaml
@@ -3,7 +3,7 @@ on:
   push:
     paths:
       - "ops/**"
-      - ".github/workflows/ralphbot*.yaml"
+      - ".github/workflows/ralphbot-infra-lint.yaml"
 
 env:
   COMMIT: ${GITHUB_SHA}


### PR DESCRIPTION
# Purpose :dart:

These changes focus the scope in which the `ralphbot-infra-lint` Github Workflow is invoked. This is because it makes more sense to only run if itself has been modified, rather than an adjacent workflow file.  i.e. infra tests shouldn't need to run if the `golang` source code is modified and its linting were to trigger.

# Context :brain:

During https://github.com/therealvio/ralphbot/pull/87, it was observed that the `golang` code changes were not deployed. This was due to a dependency on having the linting workflow run. Although [adding a manual invocation trigger](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) would work, these changes were necessary anyway.

Eventually, tests for the `golang` code will be added, and will be a valid trigger, so having the manual step will not be required. Though that doesn't mean that the trigger logic will not be revisited.
