### PR TITLE
Adds ARM64 Cross-Compilation, and relevant Infra Changes

### DIFF
--- a/.github/workflows/ralphbot-deploy.yaml
+++ b/.github/workflows/ralphbot-deploy.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: "Build Ralphbot Container Image"
         run: |
-          docker build --tag ${{ env.APP_IMAGE_NAMETAG }}:$VERSION .
+          docker build --build-arg MAKE_TARGET=build-fargate --tag ${{ env.APP_IMAGE_NAMETAG }}:$VERSION .
 
       - name: "Login to Ralphbot ECR"
         uses: docker/login-action@v2

--- a/ops/__tests__/__snapshots__/ralphbot-ops-stack.test.ts.snap
+++ b/ops/__tests__/__snapshots__/ralphbot-ops-stack.test.ts.snap
@@ -135,6 +135,9 @@ Object {
         "RequiresCompatibilities": Array [
           "FARGATE",
         ],
+        "RuntimePlatform": Object {
+          "CpuArchitecture": "ARM64",
+        },
         "TaskRoleArn": Object {
           "Fn::GetAtt": Array [
             "TaskDefinitionTaskRoleFD40A61D",

--- a/ops/src/stacks/ralphbot-ops-stack.ts
+++ b/ops/src/stacks/ralphbot-ops-stack.ts
@@ -43,6 +43,9 @@ export class RalphbotStack extends Stack {
       {
         cpu: 256,
         memoryLimitMiB: 512,
+        runtimePlatform: {
+          cpuArchitecture: ecs.CpuArchitecture.ARM64,
+        },
       }
     )
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -6,8 +6,6 @@ COPY . ./
 
 RUN go mod download && go mod verify
 RUN GOOS=linux CGO_ENABLED=0 go build -v -o bin/ralphbot ./cmd/ralphbot
-#CGO_ENABLED=0 to force a static build. Next stage of build uses an image that has libraries in different locations
-#https://stackoverflow.com/a/36308464
 
 FROM public.ecr.aws/docker/library/golang:1.18.3-alpine
 WORKDIR /app

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,11 +1,16 @@
 FROM public.ecr.aws/docker/library/golang:1.18.3 as build_image
 
+#Build the fargate binary when the "build-deployment-binary" argument is passed, or use "make build" target by default
+#This argument shouldn't need to be used in a local development context unless testing the use of the argument
+ARG MAKE_TARGET="build"
+
 WORKDIR /app
 
 COPY . ./
 
 RUN go mod download && go mod verify
-RUN GOOS=linux CGO_ENABLED=0 go build -v -o bin/ralphbot ./cmd/ralphbot
+
+RUN make ${MAKE_TARGET}
 
 FROM public.ecr.aws/docker/library/golang:1.18.3-alpine
 WORKDIR /app

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,6 +11,8 @@ mod:
 .PHONY: build
 build: bin mod
 	GOOS=linux CGO_ENABLED=0 go build -v -o bin/ralphbot ./cmd/ralphbot
+#CGO_ENABLED=0 to force a static build. Next stage of build uses an image that has libraries in different locations
+#https://stackoverflow.com/a/36308464
 
 .PHONY: build-deployment-binary
 build-fargate: bin mod

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,6 +12,10 @@ mod:
 build: bin mod
 	GOOS=linux CGO_ENABLED=0 go build -v -o bin/ralphbot ./cmd/ralphbot
 
+.PHONY: build-deployment-binary
+build-fargate: bin mod
+	GOARCH=arm64 GOOS=linux CGO_ENABLED=0 go build -v -o bin/ralphbot ./cmd/ralphbot
+
 .PHONY: local
 local: bin mod build
 	docker-compose -f docker-compose-local.yaml up --build


### PR DESCRIPTION
# Purpose :dart:

These changes change the Fargate Task Definition to run on ARM64 CPU Architecture. This is to take advantages of the cost savings, and performance benefits available on AWS Graviton CPUs.

Additionally, the `golang` `Dockerfile` has received a change to the `RUN` command that previously built the `golang` binary to use a `make` target to build the binary based on the host machine's CPU architecture, or to cross-compile as an ARM64 binary. In order to select the appropriate target, an `ARG` has been added to the Dockerfile that can be used to explicitly use a specific `make` target, or use the standard `make build` target. This change is so that during deployment, there is an explicit means to build an ARM64 binary using the same tools as before, and hopefully not add extra friction to either the local development or deployment process.

Although the Github actions do not yet use the `make` targets, these changes are a step towards making this a possibility now that the targets are available.

# Context :brain:

Part of an effort to reduce running costs of `ralphbot`, as well as streamline the build and deployment