### PR TITLE
Fix Make Target & GHA Trigger Workaround

### DIFF
--- a/.github/workflows/ralphbot-infra-lint.yaml
+++ b/.github/workflows/ralphbot-infra-lint.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - "ops/**"
       - ".github/workflows/ralphbot-infra-lint.yaml"
+      - "src/**" #Temporary hack, until golang source code linting has been added.
 
 env:
   COMMIT: ${GITHUB_SHA}

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ build: bin mod
 #https://stackoverflow.com/a/36308464
 
 .PHONY: build-deployment-binary
-build-fargate: bin mod
+build-deployment-binary: bin mod
 	GOARCH=arm64 GOOS=linux CGO_ENABLED=0 go build -v -o bin/ralphbot ./cmd/ralphbot
 
 .PHONY: local


### PR DESCRIPTION
# Purpose :dart:

These changes correct a missing change in #93, without this, the build process doesn't work.

Additionally, a workaround has been added so that while the `golang` code within `src` changes are made, the `infra` linting workflow will run, and eventually trigger the `deploy` workflow. This is a temporary fix to enable deployments to happen while working within the `src` directory.

# Context :brain:

- Failed Workflow run: https://github.com/therealvio/ralphbot/runs/8273554319?check_suite_focus=true
