### PR TITLE
chore(ops): Fixes gitignore paths for infra stack tests, and replaces cleanup yarn scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ cdk.context.json
 # TS
 *.d.ts
 ops/src/**/*.js
-ops/test/**/*.js
+ops/__tests__/**/*.js
 
 # yarn
 yarn-error.log

--- a/ops/package.json
+++ b/ops/package.json
@@ -9,8 +9,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
-    "rimraf": "./node_modules/rimfra/bin.js",
-    "clean": "rimraf ./lib/*.js && rimraf ./lib/*.d.ts && rimraf ./src/*.js && rimraf ./src/*.d.ts && rimraf ./src/**/*.js && rimraf ./src/**/*.d.ts",
+    "clean": "yarn build --build --clean",
     "eslint": "eslint . --ext .ts --ignore-pattern '*.d.ts'",
     "prettier": "prettier --check '**/*'",
     "lint": "yarn -s eslint && yarn -s prettier",
@@ -31,7 +30,6 @@
     "eslint-plugin-sort-imports-es6-autofix": "0.6.0",
     "jest": "29.0.2",
     "prettier": "2.7.1",
-    "rimraf": "3.0.2",
     "ts-jest": "29.0.0",
     "ts-node": "10.9.1",
     "typescript": "4.8.2"


### PR DESCRIPTION
# Purpose :dart:

These changes fix an incorrect path set for `.gitignore`, and replaces `rimraf` with the native `tsc --build --clean` command. Both of these combined simplify the effort required to keep the repository clean of build artifacts.

# Context :brain:

During some perusing of Stack Overflow, I ran into a [thread describing built-in cleanup mechanisms for `tsc`](https://stackoverflow.com/questions/34565872/how-to-delete-compiled-js-files-from-previous-typescript-ts-files) that was encouraging enough for myself to remove `rimraf`.

# Notes :notebook:
- [`tsc` CLI Options](https://www.typescriptlang.org/docs/handbook/compiler-options.html)
