### PR TITLE
ci(GHA): Adds Linting workflow for ralphbot's source code

### DIFF
--- a/.github/workflows/ralphbot-deploy.yaml
+++ b/.github/workflows/ralphbot-deploy.yaml
@@ -2,8 +2,8 @@ name: Ralphbot Deploy Actions
 on:
   workflow_run:
     workflows:
-      - Ralphbot Infra Stack Test
-      - Ralphbot Bot Source Code Test
+      - Ralphbot Infra Stack Linting & Testing
+      - Ralphbot Bot Source Code Linting
     branches:
       - main
     types:

--- a/.github/workflows/ralphbot-deploy.yaml
+++ b/.github/workflows/ralphbot-deploy.yaml
@@ -3,6 +3,7 @@ on:
   workflow_run:
     workflows:
       - Ralphbot Infra Stack Test
+      - Ralphbot Bot Source Code Test
     branches:
       - main
     types:

--- a/.github/workflows/ralphbot-ops-lint.yaml
+++ b/.github/workflows/ralphbot-ops-lint.yaml
@@ -3,7 +3,7 @@ on:
   push:
     paths:
       - "ops/**"
-      - ".github/workflows/ralphbot-infra-lint.yaml"
+      - ".github/workflows/ralphbot-ops-lint.yaml"
       - "src/**" #Temporary hack, until golang source code linting has been added.
 
 env:

--- a/.github/workflows/ralphbot-ops-lint.yaml
+++ b/.github/workflows/ralphbot-ops-lint.yaml
@@ -4,7 +4,6 @@ on:
     paths:
       - "ops/**"
       - ".github/workflows/ralphbot-ops-lint.yaml"
-      - "src/**" #Temporary hack, until golang source code linting has been added.
 
 env:
   COMMIT: ${GITHUB_SHA}

--- a/.github/workflows/ralphbot-ops-lint.yaml
+++ b/.github/workflows/ralphbot-ops-lint.yaml
@@ -1,4 +1,4 @@
-name: Ralphbot Infra Stack Test
+name: Ralphbot Infra Stack Linting & Testing
 on:
   push:
     paths:

--- a/.github/workflows/ralphbot-src-lint.yaml
+++ b/.github/workflows/ralphbot-src-lint.yaml
@@ -23,3 +23,20 @@ jobs:
       - name: Check 'go mod tidy' was run
         working-directory: ${{env.WORK_DIR}}
         run: make deps
+
+  go-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: ${{env.WORK_DIR}}/go.mod
+          cache-dependency-path: ${{env.WORK_DIR}}/go.sum
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          working-directory: ${{env.WORK_DIR}}
+          args: "--timeout=5m"

--- a/.github/workflows/ralphbot-src-lint.yaml
+++ b/.github/workflows/ralphbot-src-lint.yaml
@@ -1,0 +1,25 @@
+name: Ralphbot Bot Source Code Test
+on:
+  push:
+    paths:
+      - "src/**"
+      - ".github/workflows/ralphbot-src-lint.yaml"
+
+env:
+  WORK_DIR: ./src
+
+jobs:
+  check-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: ${{env.WORK_DIR}}/go.mod
+          cache-dependency-path: ${{env.WORK_DIR}}/go.sum
+
+      - name: Check 'go mod tidy' was run
+        working-directory: ${{env.WORK_DIR}}
+        run: make deps

--- a/.github/workflows/ralphbot-src-lint.yaml
+++ b/.github/workflows/ralphbot-src-lint.yaml
@@ -1,4 +1,4 @@
-name: Ralphbot Bot Source Code Test
+name: Ralphbot Bot Source Code Linting
 on:
   push:
     paths:

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,10 @@ clean:
 mod:
 	go mod download
 
+deps: mod
+	go mod tidy
+	git diff --exit-code
+
 .PHONY: build
 build: bin mod
 	GOOS=linux CGO_ENABLED=0 go build -v -o bin/ralphbot ./cmd/ralphbot

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,5 +1,3 @@
-github.com/bwmarrin/discordgo v0.24.0 h1:Gw4MYxqHdvhO99A3nXnSLy97z5pmIKHZVJ1JY5ZDPqY=
-github.com/bwmarrin/discordgo v0.24.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/bwmarrin/discordgo v0.25.0 h1:NXhdfHRNxtwso6FPdzW2i3uBvvU7UIQTghmV2T4nqAs=
 github.com/bwmarrin/discordgo v0.25.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/src/internal/dadjoke/dadjoke.go
+++ b/src/internal/dadjoke/dadjoke.go
@@ -23,12 +23,15 @@ var (
 
 	CommandHandlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
 		"dad-joke": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
 					Content: dadJoke(i, jokes),
 				},
 			})
+			if err != nil {
+				log.Printf("Failed to respond to interaction: %v", err)
+			}
 		},
 	}
 )
@@ -46,7 +49,10 @@ func getJokes() []string {
 
 	jokeArray := StructJokes{}
 
-	json.Unmarshal([]byte(jokesFile), &jokeArray)
+	err = json.Unmarshal([]byte(jokesFile), &jokeArray)
+	if err != nil {
+		log.Printf("Unable to Unmarshal : %v", err)
+	}
 
 	return jokeArray.Jokes //json.Unmarshal([]byte(jokesFile), StructJokes)
 

--- a/src/internal/guidefetch/guidefetch.go
+++ b/src/internal/guidefetch/guidefetch.go
@@ -77,12 +77,15 @@ var (
 				content = "Oops, something has gone wrong!\n"
 				log.Printf("fetch-guide has ran into `default` in switch statement! Value: %v", i.ApplicationCommandData().Options[0].Name)
 			}
-			s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseChannelMessageWithSource,
 				Data: &discordgo.InteractionResponseData{
 					Content: content,
 				},
 			})
+			if err != nil {
+				log.Printf("Failed to respond to interaction: %v", err)
+			}
 		},
 	}
 )


### PR DESCRIPTION
# Purpose :dart:

These changes add linting Github Actions workflows for `ralphbot`'s `golang` source code. This is so that code quality can be ensured throughout the lifecycle of `ralphbot`. Eventually, custom rules can be added to further define opinionated formatting, though for now the default linting rules are more than acceptable.

These changes are the first step towards eventually setting up testing via the Github Actions workflow.

Additionally, small changes were made to the `infra` Github Actions workflow such as the scope of when to trigger, and the name of the workflow itself.

# Context :brain:

These changes are part of an effort to increase confidence in `golang` code-specific changes, and dependency updates during development.
