### PR TITLE
chore: Changes `ralphbot` service image to alpine

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download && go mod verify
 
 RUN make ${MAKE_TARGET}
 
-FROM public.ecr.aws/docker/library/golang:1.19-alpine
+FROM public.ecr.aws/docker/library/alpine:latest
 WORKDIR /app
 COPY --from=build_image /app/bin/ralphbot ./
 COPY --from=build_image /app/internal/dadjoke/jokes.json ./


### PR DESCRIPTION
# Purpose :dart:

The container image for `ralphbot` has been changed from the `golang`-specific image to the standard `alpine` image.

Given that `ralphbot` is a `golang` app, it compiles everything it needs into the binary during build time. This means, it isn't necessary to have anything in the container image besides the Linux kernal and a very light distro.

Doing this change also reduces the final `ralphbot` image to 13MB from 330MB at the time of this commit.

# Context :brain:

During some purusing of the `ralphbot` repository, It was identified that the container image used for `ralphbot` didn't need to be as large as it was given that only the binary is really needed for `ralphbot` to run on the container.
