### PR TITLE
refactor: Change module import paths

### DIFF
--- a/src/cmd/ralphbot/main.go
+++ b/src/cmd/ralphbot/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"log"
 
+	"ralphbot/internal/config"
+	"ralphbot/internal/discord"
+
 	"github.com/bwmarrin/discordgo"
-	"github.com/ralphbot/internal/config"
-	"github.com/ralphbot/internal/discord"
 )
 
 var (

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,4 +1,4 @@
-module github.com/ralphbot
+module ralphbot
 
 go 1.19
 

--- a/src/internal/discord/bot.go
+++ b/src/internal/discord/bot.go
@@ -6,13 +6,14 @@ import (
 	"os"
 	"os/signal"
 
+	"ralphbot/internal/command/dadjoke"
+	"ralphbot/internal/command/guidefetch"
+	"ralphbot/internal/config"
+
 	"github.com/bwmarrin/discordgo"
-	"github.com/ralphbot/internal/command/dadjoke"
-	"github.com/ralphbot/internal/command/guidefetch"
-	"github.com/ralphbot/internal/config"
 )
 
-//Starts the `ralphbot` service
+// Starts the `ralphbot` service
 func StartBotService(s *discordgo.Session, env *config.EnvConfig) {
 	s.AddHandler(func(s *discordgo.Session, r *discordgo.Ready) {
 		log.Printf("Logged in as: %v#%v", s.State.User.Username, s.State.User.Discriminator)

--- a/src/internal/discord/command.go
+++ b/src/internal/discord/command.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"log"
 
+	"ralphbot/internal/config"
+
 	"github.com/bwmarrin/discordgo"
-	"github.com/ralphbot/internal/config"
 )
 
-//Registers commands for `ralphbot` service.
-//If `GUILD_ID` is passed, then the command is set as a guild command, and will not be registered globally. However, it will be immediately registered exclusively
-//to the Discord server (guild). If `GUILD_ID` is not passed, then the command is registered globally.
+// Registers commands for `ralphbot` service.
+// If `GUILD_ID` is passed, then the command is set as a guild command, and will not be registered globally. However, it will be immediately registered exclusively
+// to the Discord server (guild). If `GUILD_ID` is not passed, then the command is registered globally.
 func registerCommand(s *discordgo.Session, id string, commands []*discordgo.ApplicationCommand, handler map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate)) ([]*discordgo.ApplicationCommand, error) {
 	s.AddHandler(func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		if h, ok := handler[i.ApplicationCommandData().Name]; ok {


### PR DESCRIPTION
# Purpose :dart:

Import paths for `ralphbot`'s packages have been changed to a more idiomatic (and correct) convention. These changes were made forlegibility, and ease maintenance purposes. 

The "github.com" prefix didn't make sense as this project was never intended to be downloaded via `go install` or `go get`.

# Context :brain:

While doing some experiments with the project's code, it was realised that the package name was incorrect, and had made the project structure confusing with the package suggesting it was public.
