### PR TITLE
fix: Replaces deprecated set-output call in GHA

### DIFF
--- a/.github/workflows/ralphbot-deploy.yaml
+++ b/.github/workflows/ralphbot-deploy.yaml
@@ -144,7 +144,7 @@ jobs:
           REGISTRY: ${{ steps.login-ralphbot-ecr.outputs.registry }}
         run: |
           docker pull $REGISTRY/${{ env.REPOSITORY }}:$IMAGE_TAG
-          echo "::set-output name=cdk-image::$REGISTRY/${{ env.REPOSITORY }}:$IMAGE_TAG"
+          echo "cdk-image="$REGISTRY/${{ env.REPOSITORY }}:$IMAGE_TAG"" >> $GITHUB_OUTPUT
 
       - name: "Run CDK Deploy"
         run: |


### PR DESCRIPTION
# Purpose :dart:

These changes replace the `::set-output` method with the new convention of redirecting stdout to an environment variable. Currently, the `::set-output` workflow is deprecated, and by 31st March 2023, the `::set-output` method will no longer work.

# Context :brain:

In a https://github.blog/changelog/2022-10-11-github-actions-deprecating-save -state-and-set-output-commands/, the `::set-output` method is being deprecated in favour of redirecting outputs to a dedicated environment variable.
