### PR TITLE
chore: Adds caching to setup-golang jobs

### DIFF
--- a/.github/workflows/ralphbot-src-lint.yaml
+++ b/.github/workflows/ralphbot-src-lint.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: ${{env.WORK_DIR}}/go.mod
+          cache: true
           cache-dependency-path: ${{env.WORK_DIR}}/go.sum
 
       - name: Check 'go mod tidy' was run
@@ -33,6 +34,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: ${{env.WORK_DIR}}/go.mod
+          cache: true
           cache-dependency-path: ${{env.WORK_DIR}}/go.sum
 
       - name: Lint


### PR DESCRIPTION
# Purpose :dart:

These changes enable the caching configuration of `setup-go` Github action. This change should enable faster workflow runs as the project grows.

# Context :brain:

It was identified that caching, although had a path referenced, was not actually occurring. 
