### PR TITLE
chore: Updates Github Action

### DIFF
--- a/.github/workflows/ralphbot-deploy.yaml
+++ b/.github/workflows/ralphbot-deploy.yaml
@@ -34,7 +34,7 @@ jobs:
           echo "IMAGE_TAG="cdk-$(date '+%Y.%m.%d'.${GITHUB_SHA::6})"" >> $GITHUB_ENV
 
       - name: "Configure AWS Credentials"
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -50,7 +50,7 @@ jobs:
           docker build --tag ${{ env.CDK_IMAGE_NAMETAG }}:$IMAGE_TAG .
 
       - name: "Configure AWS Credentials - Change Region to Deployment Region"
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ${{ secrets.AWS_REGION }}
 
@@ -82,7 +82,7 @@ jobs:
           echo "IMAGE_TAG="$(date '+%Y.%m.%d'.${GITHUB_SHA::6})"" >> $GITHUB_ENV
 
       - name: "Configure AWS Credentials"
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -98,7 +98,7 @@ jobs:
           docker build --build-arg MAKE_TARGET=build-deployment-binary --tag ${{ env.APP_IMAGE_NAMETAG }}:$IMAGE_TAG .
 
       - name: "Configure AWS Credentials - Change Region to Deployment Region"
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ${{ secrets.AWS_REGION }}
 
@@ -128,7 +128,7 @@ jobs:
           echo "IMAGE_TAG="cdk-$(date '+%Y.%m.%d'.${GITHUB_SHA::6})"" >> $GITHUB_ENV
 
       - name: "Configure AWS Credentials"
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ralphbot-ops-lint.yaml
+++ b/.github/workflows/ralphbot-ops-lint.yaml
@@ -28,7 +28,7 @@ jobs:
           echo "IMAGE_TAG="$(date '+%Y.%m.%d'.${GITHUB_SHA::6})"" >> $GITHUB_ENV
 
       - name: "Configure AWS Credentials"
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
# Purpose :dart:

These changes resolve NodeJS v12 deprecation warnings when using the `aws-actions/configure-aws-credentials` Github Action.

# Context :brain:

Github Actions is deprecating steps based on NodeJS 12. The aws-actions team have a seperate-branch version of the workflow that is based on NodeJS v16. . 

# Notes :notebook:
Github Issue: https://github.com/aws-actions/configure-aws-credentials/ issues/489
