### PR TITLE
chore: Adds automerge schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:base", ":dependencyDashboard"],
   "ignorePaths": ["src/Dockerfile", "ops/Dockerfile"],
   "schedule": ["after 7am and before 7pm every weekday"],
+  "automergeSchedule": ["after 7am and before 7pm every weekday"],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
# Purpose :dart:

This change adds an automerge schedule for `renovate` so that it matches the branch creation schedule.

# Context :brain:

It was identified that automerge scheduling wasn't configured, refer to the screenshot below.

<img width="834" alt="Screenshot 2022-10-29 at 12 42 17 am" src="https://user-images.githubusercontent.com/41095688/198619155-ff7eba11-7ac5-449f-a456-982168dad2c3.png">
