### PR TITLE
feat: Adds `link-dump` command

### DIFF
--- a/src/internal/command/linkdump/linkdump.go
+++ b/src/internal/command/linkdump/linkdump.go
@@ -1,0 +1,81 @@
+package linkdump
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+type LinkDetails struct {
+	Name string
+	URL  string
+}
+
+type Links struct {
+	Links []LinkDetails `json:"Links"`
+}
+
+//go:embed links.json
+var linkFile []byte
+
+var (
+	Commands = []*discordgo.ApplicationCommand{
+		//https://discord.com/developers/docs/interactions/application-commands#slash-commands
+		{
+			Name:        "link-dump",
+			Description: "Sends a link dump via DM of helpful Destiny 2-related web apps",
+		},
+	}
+
+	links, _ = getLinks(linkFile)
+
+	CommandHandlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
+		"link-dump": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			channel, err := s.UserChannelCreate(i.Member.User.ID)
+			if err != nil {
+				log.Printf("Failed to create DM channel for %v: %v", i.User.ID, err)
+			}
+
+			err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Flags:   discordgo.MessageFlagsEphemeral,
+					Content: "Check your DMs for a message from me! :smirk:",
+				},
+			})
+			if err != nil {
+				log.Printf("Failed to respond to interaction: %v", err)
+			}
+
+			_, err = s.ChannelMessageSend(channel.ID, links)
+			if err != nil {
+				log.Printf("Failed to send message to DM channel: %v", err)
+			}
+		},
+	}
+)
+
+func getLinks(b []byte) (string, error) {
+
+	var linkStruct Links
+	err := json.Unmarshal(b, &linkStruct)
+	if err != nil {
+		log.Printf("Unable to Unmarshal : %v", err)
+		return "", err
+	}
+
+	var linkSlice []string
+	for _, l := range linkStruct.Links {
+		//For some reason, markdown for links doesn't work here
+		linkElem := fmt.Sprintf("%s - <%s>", l.Name, l.URL)
+		linkSlice = append(linkSlice, linkElem)
+	}
+	content := strings.Join(linkSlice, "\n")
+
+	return content, nil
+
+}

--- a/src/internal/command/linkdump/linkdump_test.go
+++ b/src/internal/command/linkdump/linkdump_test.go
@@ -1,0 +1,33 @@
+package linkdump
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLinks(t *testing.T) {
+
+	foo := "foo - <foo.com>"
+	bar := "bar - <bar.com>"
+
+	linkJson := `{
+		"Links": [
+			{
+			  "Name": "foo",
+			  "URL": "foo.com"
+			},
+			{
+			  "Name": "bar",
+			  "URL": "bar.com"
+			}
+		]
+	}`
+
+	expected := fmt.Sprintf("%s\n%s", foo, bar)
+	links, err := getLinks([]byte(linkJson))
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, links)
+}

--- a/src/internal/command/linkdump/links.json
+++ b/src/internal/command/linkdump/links.json
@@ -1,0 +1,44 @@
+{
+  "Links": [
+    {
+      "Name": "Bray.Tech",
+      "URL": "https://bray.tech/"
+    },
+    {
+      "Name": "Destiny 2 Armour Picker",
+      "URL": "https://d2armorpicker.com/#/"
+    },
+    {
+      "Name": "Destiny 2 Checklist",
+      "URL": "https://www.d2checklist.com/"
+    },
+    {
+      "Name": "Destiny 2 Gunsmith",
+      "URL": "https://d2gunsmith.com/"
+    },
+    {
+      "Name": "Destiny Item Manager (DIM)",
+      "URL": "https://app.destinyitemmanager.com/"
+    },
+    {
+      "Name": "Destiny 2 Optimiser",
+      "URL": "https://destinyoptimizer.com/"
+    },
+    {
+      "Name": "Destiny 2 Sets",
+      "URL": "https://destinysets.com/"
+    },
+    {
+      "Name": "Destiny 2 Weekly Reset Infographic",
+      "URL": "https://www.niris.tv/blog/weekly-reset"
+    },
+    {
+      "Name": "Today in Destiny",
+      "URL": "https://www.todayindestiny.com/"
+    },
+    {
+      "Name": "Where the F**k is Xur?",
+      "URL": "https://wherethefuckisxur.com/"
+    }
+  ]
+}

--- a/src/internal/discord/bot.go
+++ b/src/internal/discord/bot.go
@@ -8,6 +8,7 @@ import (
 
 	"ralphbot/internal/command/dadjoke"
 	"ralphbot/internal/command/guidefetch"
+	"ralphbot/internal/command/linkdump"
 	"ralphbot/internal/config"
 
 	"github.com/bwmarrin/discordgo"
@@ -29,6 +30,10 @@ func StartBotService(s *discordgo.Session, env *config.EnvConfig) {
 		fmt.Printf("error: %v", err)
 	}
 	_, err = registerCommand(s, env.GuildID, dadjoke.Commands, dadjoke.CommandHandlers)
+	if err != nil {
+		fmt.Printf("error: %v", err)
+	}
+	_, err = registerCommand(s, env.GuildID, linkdump.Commands, linkdump.CommandHandlers)
 	if err != nil {
 		fmt.Printf("error: %v", err)
 	}


### PR DESCRIPTION
# Purpose :dart:

These changes add a new command: `link-dump`. The aim of this command is to provide a list of links to popular Destiny 2 web apps and tools.

This command has been added so that when Guildies ask for a link to a common web app, we can direct them to `ralphbot`, rather than hunt the link down ourselves.

# Context :brain:

This was a suggested command from a Guildie. All in the name of making `ralphbot` extra awesome 😎 
