### PR TITLE
feat: Adds light.gg link to link-dump

### DIFF
--- a/src/internal/command/linkdump/links.json
+++ b/src/internal/command/linkdump/links.json
@@ -33,6 +33,10 @@
       "URL": "https://www.niris.tv/blog/weekly-reset"
     },
     {
+      "Name": "Light.gg",
+      "URL": "https://www.light.gg/"
+    },
+    {
       "Name": "Today in Destiny",
       "URL": "https://www.todayindestiny.com/"
     },


### PR DESCRIPTION
# Purpose :dart:

This change adds [light.gg](https://www.light.gg/) to the `link-dump` links list. This is a useful tool in Destiny 2 which is used for checking the potential rolls for weapons in, and other useful stats such as perk combination popularity. 

# Context :brain:

This link was picked up by a Guildie, and was missed in the first iteration of the link dump.

