### PR TITLE
chore: Enable gomod dep automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,7 +37,7 @@
     },
     {
       "matchManagers": ["gomod"],
-      "automerge": false
+      "automerge": true
     },
     {
       "groupName": "aws-cdk",


### PR DESCRIPTION
# Purpose :dart:

Enable `gomod` dependency automerging via `renovate`.

# Context :brain:

Follow up to #412 
