### PR TITLE
feat: Add Crota's End guide subcommand

### DIFF
--- a/src/internal/command/guidefetch/guide.go
+++ b/src/internal/command/guidefetch/guide.go
@@ -9,6 +9,13 @@ type guide struct {
 }
 
 var (
+	crota = &guide{
+		Name:           "Crota's End",
+		SubCommandName: "raid-crota",
+		Description:    "Crota's End Raid",
+		GDriveLink:     "https://drive.google.com/drive/folders/1PmabG2nVyRf1yLd__KNEPaaFkACkx1XC?usp=sharing",
+	}
+
 	crypt = &guide{
 		Name:           "Deep Stone Crypt",
 		SubCommandName: "raid-crypt",
@@ -81,6 +88,7 @@ var (
 	}
 
 	Guides = []guide{
+		*crota,
 		*crypt,
 		*garden,
 		*ghosts,


### PR DESCRIPTION
# Purpose :dart:

These changes add the Crota's End `guidefetch` subcommand. This is so that guildies can request our collection of Crota's End raid material (like all the others!).

# Context :brain: 

The reprised Crota's End raid is out 👀 